### PR TITLE
Correct reference in README.md

### DIFF
--- a/test/support/http_params/README.md
+++ b/test/support/http_params/README.md
@@ -237,7 +237,7 @@ the resulting changeset on.
 
 So an exemplar that uses "today" incorrectly would tell us nothing... exemplary...
 about `VM.BulkAnimal`... *provided* we know that it uses
-`FieldValidators.namelist`. That's an interesting fact we might want
+`FieldValidators.date_order`. That's an interesting fact we might want
 to document (so long as it's easy). That way, we'd prevent
 someone else coming across these exemplars, tut-tut about a missing
 error case, and wasting time adding it.


### PR DESCRIPTION
In the section ‘Describing dependencies’, the discussion is about `FielValidators.date_order`, but the text referenced `FieldValidators.namelist`. If I understood the gist correctly, that was just a typo and should have also been `FieldVaidators.date_order`.

(If this wasn’t a typo, then maybe there’s a concept I’m missing that could be elaborated.